### PR TITLE
--container-tmpdir fix + test

### DIFF
--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -124,7 +124,7 @@ BUILD_OPTIONS_CMDLINE = {
         'container_base',
         'container_image_format',
         'container_image_name',
-        'container_tmp_path',
+        'container_tmpdir',
         'download_timeout',
         'dump_test_report',
         'easyblock',

--- a/easybuild/tools/containers.py
+++ b/easybuild/tools/containers.py
@@ -244,10 +244,13 @@ def build_singularity_image(def_path):
 
     # resolve full path to 'singularity' binary, since it may not be available via $PATH under sudo...
     singularity = which('singularity')
+    cmd_env = ''
 
-    singularity_tmp = build_option('container_tmp_path')
+    singularity_tmpdir = build_option('container_tmpdir')
+    if singularity_tmpdir:
+        cmd_env += 'SINGULARITY_TMPDIR=%s' % singularity_tmpdir
 
-    cmd = "sudo SINGULARITY_TMPDIR=%s %s build %s %s %s" % (singularity_tmp, singularity, cmd_opts, img_path, def_path)
+    cmd = ' '.join(['sudo', cmd_env, singularity, 'build', cmd_opts, img_path, def_path])
     print_msg("Running '%s', you may need to enter your 'sudo' password..." % cmd)
     run_cmd(cmd, stream_output=True)
     print_msg("Singularity image created at %s" % img_path, log=_log)

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -637,7 +637,7 @@ class EasyBuildOptions(GeneralOption):
             'build-image': ("Build container image (requires sudo privileges!)", None, 'store_true', False),
             'image-format': ("Container image format", 'choice', 'store', None, CONT_IMAGE_FORMATS),
             'image-name': ("Custom name for container image (defaults to name of easyconfig)", None, 'store', None),
-            'tmp-path': ("Path to where container image is temporarily built", None, 'store', None),
+            'tmpdir': ("Temporary directory where container image is built", None, 'store', None),
             'type': ("Type of container recipe/image to create", 'choice', 'store', DEFAULT_CONT_TYPE, CONT_TYPES),
         })
 

--- a/test/framework/containers.py
+++ b/test/framework/containers.py
@@ -229,7 +229,7 @@ class ContainersTest(EnhancedTestCase):
             "^== Singularity tool found at %s/bin/singularity" % self.test_prefix,
             "^== Singularity version '2.4.0' is 2.4 or higher ... OK",
             "^== Singularity definition file created at %s/containers/Singularity\.toy-0.0" % self.test_prefix,
-            "^== Running 'sudo .*/singularity build\s*/.* /.*', you may need to enter your 'sudo' password...",
+            "^== Running 'sudo\s*\S*/singularity build\s*/.* /.*', you may need to enter your 'sudo' password...",
             "^== Singularity image created at %s/containers/toy-0.0\.simg" % self.test_prefix,
         ]
         self.check_regexs(regexs, stdout)
@@ -246,7 +246,7 @@ class ContainersTest(EnhancedTestCase):
         stdout, stderr = self.run_main(args)
         self.assertFalse(stderr)
         regexs[-3] = "^== Singularity definition file created at %s/containers/Singularity\.foo-bar" % self.test_prefix
-        regexs[-2] = "^== Running 'sudo .*/singularity build --writable /.* /.*', you may need to enter .*"
+        regexs[-2] = "^== Running 'sudo\s*\S*/singularity build --writable /.* /.*', you may need to enter .*"
         regexs[-1] = "^== Singularity image created at %s/containers/foo-bar\.img$" % self.test_prefix
         self.check_regexs(regexs, stdout)
 
@@ -275,6 +275,13 @@ class ContainersTest(EnhancedTestCase):
         args.append('--extended-dry-run')
         stdout, stderr = self.run_main(args)
         self.assertFalse(stderr)
+        self.check_regexs(regexs, stdout)
+
+        # test use of --container-tmpdir
+        args.append('--container-tmpdir=%s' % self.test_prefix)
+        stdout, stderr = self.run_main(args)
+        self.assertFalse(stderr)
+        regexs[-3] = "^== Running 'sudo\s*SINGULARITY_TMPDIR=%s \S*/singularity build .*" % self.test_prefix
         self.check_regexs(regexs, stdout)
 
 


### PR DESCRIPTION
@migueldiascosta for https://github.com/easybuilders/easybuild-framework/pull/2483

* rename `--container-tmp-path` to `--container-tmpdir` (for consistency with `--tmpdir`)
* take into account that `--container-tmpdir` may not be specified
* enhance tests to also cover use of `--container-tmpdir