### PR TITLE
ensure ordered output in message printed by --list-prs, drop unused GITHUB_MAX_PER_PAGE from _postprocess_list_prs

### DIFF
--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -1008,7 +1008,7 @@ def list_prs(params, per_page=GITHUB_MAX_PER_PAGE):
         'direction': params[2],
         'per_page': per_page,
     }
-    print_msg("Listing PRs with parameters %s" % parameters)
+    print_msg("Listing PRs with parameters: %s" % ', '.join(k + '=' + str(parameters[k]) for k in sorted(parameters)))
 
     pr_target_account = build_option('pr_target_account')
     pr_target_repo = build_option('pr_target_repo')

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -73,7 +73,7 @@ from easybuild.tools.docs import avail_toolchain_opts, avail_easyconfig_params, 
 from easybuild.tools.docs import list_easyblocks, list_toolchains
 from easybuild.tools.environment import restore_env, unset_env_vars
 from easybuild.tools.filetools import CHECKSUM_TYPE_SHA256, CHECKSUM_TYPES
-from easybuild.tools.github import GITHUB_EB_MAIN, GITHUB_EASYCONFIGS_REPO, GITHUB_MAX_PER_PAGE
+from easybuild.tools.github import GITHUB_EB_MAIN, GITHUB_EASYCONFIGS_REPO
 from easybuild.tools.github import GITHUB_PR_DIRECTION_DESC, GITHUB_PR_ORDER_CREATED, GITHUB_PR_STATE_OPEN
 from easybuild.tools.github import GITHUB_PR_STATES, GITHUB_PR_ORDERS, GITHUB_PR_DIRECTIONS
 from easybuild.tools.github import HAVE_GITHUB_API, HAVE_KEYRING
@@ -865,7 +865,7 @@ class EasyBuildOptions(GeneralOption):
         if list_pr_direc not in GITHUB_PR_DIRECTIONS:
             raise EasyBuildError("3rd item in --list-prs ('%s') must be one of %s", list_pr_direc, GITHUB_PR_DIRECTIONS)
 
-        self.options.list_prs = (list_pr_state, list_pr_order, list_pr_direc, GITHUB_MAX_PER_PAGE)
+        self.options.list_prs = (list_pr_state, list_pr_order, list_pr_direc)
 
     def _postprocess_include(self):
         """Postprocess --include options."""

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -40,7 +40,7 @@ import easybuild.main
 import easybuild.tools.build_log
 import easybuild.tools.options
 import easybuild.tools.toolchain
-from easybuild.framework.easyblock import EasyBlock, FETCH_STEP
+from easybuild.framework.easyblock import EasyBlock 
 from easybuild.framework.easyconfig import BUILD, CUSTOM, DEPENDENCIES, EXTENSIONS, FILEMANAGEMENT, LICENSE
 from easybuild.framework.easyconfig import MANDATORY, MODULES, OTHER, TOOLCHAIN
 from easybuild.framework.easyconfig.easyconfig import EasyConfig, get_easyblock_class, robot_find_easyconfig
@@ -50,7 +50,7 @@ from easybuild.tools.config import DEFAULT_MODULECLASSES
 from easybuild.tools.config import find_last_log, get_build_log_path, get_module_syntax, module_classes
 from easybuild.tools.environment import modify_env
 from easybuild.tools.filetools import copy_dir, copy_file, download_file, mkdir, read_file, remove_file, write_file
-from easybuild.tools.github import GITHUB_RAW, GITHUB_EB_MAIN, GITHUB_EASYCONFIGS_REPO, GITHUB_MAX_PER_PAGE
+from easybuild.tools.github import GITHUB_RAW, GITHUB_EB_MAIN, GITHUB_EASYCONFIGS_REPO
 from easybuild.tools.github import URL_SEPARATOR, fetch_github_token
 from easybuild.tools.modules import Lmod
 from easybuild.tools.options import EasyBuildOptions, parse_external_modules_metadata, set_tmpdir, use_color
@@ -3216,8 +3216,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         args = ['--list-prs', 'closed,updated,asc']
         txt, _ = self._run_mock_eb(args, testing=False)
-        expected = "Listing PRs with parameters "
-        expected += "{'sort': 'updated', 'per_page': %s, 'state': 'closed', 'direction': 'asc'}" % GITHUB_MAX_PER_PAGE
+        expected = "Listing PRs with parameters: direction=asc, per_page=100, sort=updated, state=closed"
         self.assertTrue(expected in txt)
 
     def test_list_software(self):


### PR DESCRIPTION
@migueldiascosta Some final minor changes for https://github.com/easybuilders/easybuild-framework/pull/2400 ...