### PR TITLE
code cleanup in tools/github.py

### DIFF
--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -103,9 +103,12 @@ HTTP_STATUS_CREATED = 201
 KEYRING_GITHUB_TOKEN = 'github_token'
 URL_SEPARATOR = '/'
 
-VALID_CLOSE_PR_REASONS = {'archived': 'uses an archived toolchain',
-                          'inactive': 'no activity for > 6 months',
-                          'obsolete': 'obsoleted by more recent PRs'}
+VALID_CLOSE_PR_REASONS = {
+    'archived': 'uses an archived toolchain',
+    'inactive': 'no activity for > 6 months',
+    'obsolete': 'obsoleted by more recent PRs',
+}
+
 
 class Githubfs(object):
     """This class implements some higher level functionality on top of the Github api"""
@@ -1738,8 +1741,11 @@ def fetch_pr_data(pr, pr_target_account, pr_target_repo, github_user, full=False
 
     if full:
         # also fetch status of last commit
-        pr_head_sha = pr_data['head']['sha']
-        status_url = lambda g: g.repos[pr_target_account][pr_target_repo].commits[pr_head_sha].status
+
+        def status_url(gh):
+            """Helper function to grab status of latest commit."""
+            return gh.repos[pr_target_account][pr_target_repo].commits[pr_data['head']['sha']].status
+
         status, status_data = github_api_get_request(status_url, github_user)
         if status != HTTP_STATUS_OK:
             raise EasyBuildError("Failed to get status of last commit for PR #%d from %s/%s (status: %d %s)",
@@ -1747,7 +1753,10 @@ def fetch_pr_data(pr, pr_target_account, pr_target_repo, github_user, full=False
         pr_data['status_last_commit'] = status_data['state']
 
         # also fetch comments
-        comments_url = lambda g: g.repos[pr_target_account][pr_target_repo].issues[pr].comments
+        def comments_url(gh):
+            """Helper function to grab comments for this PR."""
+            return gh.repos[pr_target_account][pr_target_repo].issues[pr].comments
+
         status, comments_data = github_api_get_request(comments_url, github_user)
         if status != HTTP_STATUS_OK:
             raise EasyBuildError("Failed to get comments for PR #%d from %s/%s (status: %d %s)",
@@ -1755,7 +1764,10 @@ def fetch_pr_data(pr, pr_target_account, pr_target_repo, github_user, full=False
         pr_data['issue_comments'] = comments_data
 
         # also fetch reviews
-        reviews_url = lambda g: g.repos[pr_target_account][pr_target_repo].pulls[pr].reviews
+        def reviews_url(gh):
+            """Helper function to grab reviews for this PR"""
+            return gh.repos[pr_target_account][pr_target_repo].pulls[pr].reviews
+
         status, reviews_data = github_api_get_request(reviews_url, github_user)
         if status != HTTP_STATUS_OK:
             raise EasyBuildError("Failed to get reviews for PR #%d from %s/%s (status: %d %s)",

--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -118,15 +118,13 @@ class GithubTest(EnhancedTestCase):
             print "Skipping test_fetch_pr_data, no GitHub token available?"
             return
 
-        status, pr_data, pr_url = gh.fetch_pr_data(1, GITHUB_USER, GITHUB_REPO, GITHUB_TEST_ACCOUNT)
+        pr_data, pr_url = gh.fetch_pr_data(1, GITHUB_USER, GITHUB_REPO, GITHUB_TEST_ACCOUNT)
 
-        self.assertEquals(gh.HTTP_STATUS_OK, status)
         self.assertEquals(pr_data['number'], 1)
         self.assertEquals(pr_data['title'], "a pr")
         self.assertFalse(any(key in pr_data for key in ['issue_comments', 'review', 'status_last_commit']))
 
-        status, pr_data, pr_url = gh.fetch_pr_data(2, GITHUB_USER, GITHUB_REPO, GITHUB_TEST_ACCOUNT, full=True)
-        self.assertEquals(gh.HTTP_STATUS_OK, status)
+        pr_data, pr_url = gh.fetch_pr_data(2, GITHUB_USER, GITHUB_REPO, GITHUB_TEST_ACCOUNT, full=True)
         self.assertEquals(pr_data['number'], 2)
         self.assertEquals(pr_data['title'], "an open pr (do not close this please)")
         self.assertTrue(pr_data['issue_comments'])
@@ -190,14 +188,6 @@ class GithubTest(EnhancedTestCase):
                 self.assertEqual(sorted(all_ecs), sorted([os.path.basename(f) for f in ec_files]))
             except URLError, err:
                 print "Ignoring URLError '%s' in test_fetch_easyconfigs_from_pr" % err
-
-        try:
-            # PR for EasyBuild v1.13.0 release (250+ commits, 218 files changed)
-            err_msg = "PR #897 contains more than .* commits, can't obtain last commit"
-            self.assertErrorRegex(EasyBuildError, err_msg, gh.fetch_easyconfigs_from_pr, 897,
-                                  github_user=GITHUB_TEST_ACCOUNT)
-        except URLError, err:
-            print "Ignoring URLError '%s' in test_fetch_easyconfigs_from_pr" % err
 
     def test_fetch_latest_commit_sha(self):
         """Test fetch_latest_commit_sha function."""


### PR DESCRIPTION
@migueldiascosta for https://github.com/easybuilders/easybuild-framework/pull/2401

There were a couple more places where `fetch_pr_data` came in useful, and there was a whole block of basically dead code that wasn't cleaned up in `merge_pr`.

I also changed `fetch_pr_data` to not return `status`, I don't see the point of that?