### PR TITLE
enhance test for check_pr_eligible_to_merge to catch fixed bug w.r.t. last test report having to be successful

### DIFF
--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -474,6 +474,7 @@ class GithubTest(EnhancedTestCase):
 
         pr_data['issue_comments'] = [
             {'body': "@easybuild-easyconfigs/maintainers: please review/merge?"},
+            {'body': "Test report by @boegel\n**SUCCESS**\nit's all good!"},
             {'body': "Test report by @boegel\n**FAILED**\nnothing ever works..."},
             {'body': "this is just a regular comment"},
         ]


### PR DESCRIPTION
@migueldiascosta It's trivial to enhance the existing test for `check_pr_eligible_to_merge` to catch the bug you fixed in https://github.com/easybuilders/easybuild-framework/pull/2720/files, so let's do so...