### PR TITLE
mention PR id in warning message when easyblocks are included from multiple locations + catch output in test

### DIFF
--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -1463,8 +1463,9 @@ def set_up_configuration(args=None, logfile=None, testing=False, silent=False):
             included_from_file = set([os.path.basename(eb) for eb in included_paths])
             included_twice = included_from_pr & included_from_file
             if included_twice:
-                print_warning("EasyBlock(s) %s included from multiple locations, the one from a PR will be used" %
-                              ','.join(included_twice))
+                warning_msg = "One or more easyblocks included from multiple locations: %s " % ', '.join(included_twice)
+                warning_msg += "(the one(s) from PR #%s will be used)" % pr_easyblocks
+                print_warning(warning_msg)
 
         for easyblock in included_from_pr:
             print_msg("easyblock %s included from PR #%s" % (easyblock, pr_easyblocks), log=log)

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2885,8 +2885,16 @@ class CommandLineOptionsTest(EnhancedTestCase):
             '--unittest-file=%s' % self.logfile,
             '--github-user=%s' % GITHUB_TEST_ACCOUNT,
         ]
+        self.mock_stderr(True)
+        self.mock_stdout(True)
         self.eb_main(args, logfile=dummylogfn, raise_error=True)
+        stderr, stdout = self.get_stderr(), self.get_stdout()
+        self.mock_stderr(False)
+        self.mock_stdout(False)
         logtxt = read_file(self.logfile)
+
+        self.assertFalse(stderr)
+        self.assertEqual(stdout, "== easyblock cmakemake.py included from PR #1915\n")
 
         # easyblock included from pr is found
         path_pattern = os.path.join(self.test_prefix, '.*', 'included-easyblocks-.*', 'easybuild', 'easyblocks')
@@ -2925,8 +2933,18 @@ class CommandLineOptionsTest(EnhancedTestCase):
             '--unittest-file=%s' % self.logfile,
             '--github-user=%s' % GITHUB_TEST_ACCOUNT,
         ]
+        self.mock_stderr(True)
+        self.mock_stdout(True)
         self.eb_main(args, logfile=dummylogfn, raise_error=True)
+        stderr, stdout = self.get_stderr(), self.get_stdout()
+        self.mock_stderr(False)
+        self.mock_stdout(False)
         logtxt = read_file(self.logfile)
+
+        expected = "WARNING: One or more easyblocks included from multiple locations: "
+        expected += "cmakemake.py (the one(s) from PR #1915 will be used)"
+        self.assertEqual(stderr.strip(), expected)
+        self.assertEqual(stdout, "== easyblock cmakemake.py included from PR #1915\n")
 
         # easyblock included from pr is found
         path_pattern = os.path.join(self.test_prefix, '.*', 'included-easyblocks-.*', 'easybuild', 'easyblocks')
@@ -2958,8 +2976,16 @@ class CommandLineOptionsTest(EnhancedTestCase):
             '--github-user=%s' % GITHUB_TEST_ACCOUNT,
             '--extended-dry-run',
         ]
+        self.mock_stderr(True)
+        self.mock_stdout(True)
         self.eb_main(args, logfile=dummylogfn, raise_error=True)
+        stderr, stdout = self.get_stderr(), self.get_stdout()
+        self.mock_stderr(False)
+        self.mock_stdout(False)
         logtxt = read_file(self.logfile)
+
+        self.assertFalse(stderr)
+        self.assertEqual(stdout, "== easyblock cmake.py included from PR #1936\n")
 
         # easyconfig from pr is found
         ec_pattern = os.path.join(self.test_prefix, '.*', 'files_pr10487', 'c', 'CMake',


### PR DESCRIPTION
@migueldiascosta for https://github.com/easybuilders/easybuild-framework/pull/3311